### PR TITLE
test install

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Then you can install lua-capnproto using the following commands:
 
 Let's compile an example file to test whether lua-capnproto was installed successfully:
 
-    $capnp compile -olua proto/example.capnp
+    $capnp compile -olua proto/example.capnp proto/enums.capnp proto/lua.capnp proto/struct.capnp
 
 Normally, you should see no errors and a file named "proto/example_capnp.lua" is generated.
 

--- a/example/main.lua
+++ b/example/main.lua
@@ -6,7 +6,7 @@ local util = require "capnp.util"
 local data = {
     people = {
         {
-            id = "123",
+            id = 123,
             name = "Alice",
             email = "alice@example.com",
             phones = {
@@ -20,7 +20,7 @@ local data = {
             },
         },
         {
-            id = "456",
+            id = 456,
             name = "Bob",
             email = "bob@example.com",
             phones = {


### PR DESCRIPTION
1.
after install lua-capnproto by luarocks, the following test does not work.
```
$ capnp compile -olua proto/example.capnp
```

2.
File main.lua of example directory
id should be interger not string.