### PR TITLE
serialization: add method to serialize without ffi.string conversion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION:=0.1.3-1
+VERSION:=0.1.3-2
 CXXFLAGS:=-std=gnu++11 -g -Iproto -I/usr/local/include
 LDFLAGS:=-L/usr/local/lib -lcapnp -lkj -pthread
 CAPNP_TEST:=../capnp_test

--- a/capnp/compile.lua
+++ b/capnp/compile.lua
@@ -524,7 +524,8 @@ end
 function comp_serialize(res, name)
     insert(res, format([[
 
-    serialize = function(data, p8, size)
+    -- Serialize and return pointer to char[] and size
+    serialize_cdata = function(data, p8, size)
         if not p8 then
             size = _M.%s.calc_size(data)
 
@@ -543,9 +544,14 @@ function comp_serialize(res, name)
         -- skip header & struct pointer
         _M.%s.flat_serialize(data, p32 + 4)
 
+        return p8, size
+    end,
+
+    serialize = function(data, p8, size)
+        p8, size = _M.%s.serialize_cdata(data, p8, size)
         return ffi_string(p8, size)
     end,
-]], name, name, name))
+]], name, name, name, name))
 end
 
 function comp_flat_serialize(res, nodes, struct, fields, size, name)

--- a/lua-capnproto.rockspec
+++ b/lua-capnproto.rockspec
@@ -1,8 +1,8 @@
 package = "lua-capnproto"
-version = "0.1.3-1"
+version = "0.1.3-2"
 source = {
    url = "git://github.com/cloudflare/lua-capnproto",
-   tag = "v0.1.3-1",
+   tag = "v0.1.3-2",
 }
 description = {
    summary = "Lua-capnproto is a pure lua implementation of capnproto based on LuaJIT.",

--- a/tests/10-encode-decode.lua
+++ b/tests/10-encode-decode.lua
@@ -741,4 +741,16 @@ function test_list_uint16_size()
     assert_equal(16 + 8 * 6 + 72, hw_capnp.T3.calc_size(data))
 end
 
+function test_serialize_cdata()
+    local data = {
+        i0 = 32,
+    }
+
+    assert_equal(128, hw_capnp.T1.calc_size(data))
+    local bin   = hw_capnp.T1.serialize(data)
+    local arr, len = hw_capnp.T1.serialize_cdata(data)
+    assert_equal(#bin, len)
+    assert_equal(bin, ffi.string(arr, len))
+end
+
 return _G


### PR DESCRIPTION
This adds a method serialize_cdata() that does exactly the same thing
as serialize(), except it returns a pointer to FFI array and length.
This is a workaround for degraded performance when the generated
messages have colliding hashes when interning with ffi.string.
The ffi.string generates a hash of the string by looking at the first
4B, middle 4B, and last 4B. When these are the same, it causes a hash
collision with an another string. This is unfortunately not something
that the caller is always able to affect, so the only workaround is
to not intern at all and use the char[] directly.

The generated function has the same function signature as serialize(),
except it has two returns values - pointer to the array, and the message length.